### PR TITLE
qol: Deterministic `DisputeGameFactory` deployment

### DIFF
--- a/.env.devnet
+++ b/.env.devnet
@@ -4,6 +4,4 @@ export OP_CHALLENGER_KEY="ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d
 export OP_CHALLENGER_L1_WS="ws://127.0.0.1:8546"
 export OP_CHALLENGER_TRUSTED_OP_NODE_RPC="http://localhost:7545"
 export OP_CHALLENGER_L2OO="0x6900000000000000000000000000000000000000"
-
-# Paste the DisputeGameFactory env variable logged by `start_devnet.sh` here.
-
+export OP_CHALLENGER_DGF="0x4d1B6A3810741ee758422f3027dB2eBF5CA52203"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,11 +13,10 @@ To work in this repo, you'll need to install:
 ```sh
 git clone git@github.com:clabby/op-challenger.git
 ```
-2. Configure your environment
+2. Start the devnet.
 ```sh
-cp .env.devnet .env
-nvim .env
-source .env
+nvim ./start_devnet.sh # edit MONOREPO_DIR accordingly
+./start_devnet.sh
 ```
 3. Start the `op-challenger` with information, warning, and error traces enabled.
 ```sh

--- a/start_devnet.sh
+++ b/start_devnet.sh
@@ -13,7 +13,10 @@ MONOREPO_DIR="$HOME/dev/optimism/monorepo"
 (cd ./testdata/mock-dgf && forge script script/DeployMocks.s.sol --rpc-url http://localhost:8545 --private-key $OP_CHALLENGER_KEY --broadcast)
 
 echo "----------------------------------------------------------------"
-echo " - Paste the environment variable logged by the forge script"
-echo " - into the \`.env.devnet\` file and then source it again before"
-echo " - running the \`op-challenger\`."
+echo "                     Devnet is up and running                   " 
+echo " - L1 RPC: http://localost:8545"
+echo " - L2 WS: ws://localost:8546"
+echo " - L2 RPC: http://localost:9545"
+echo " - OP Node RPC: http://localost:7545"
+echo " - Dispute game factory: $OP_CHALLENGER_DGF"
 echo "----------------------------------------------------------------"

--- a/testdata/mock-dgf/script/DeployMocks.s.sol
+++ b/testdata/mock-dgf/script/DeployMocks.s.sol
@@ -9,10 +9,16 @@ import { MockDisputeGame_OutputAttestation } from "src/MockDisputeGame_OutputAtt
 contract DeployMocks is Script {
     function run() public {
         // Deploy the mock dispute game factory
+        bytes memory bytecode = type(MockDisputeGameFactory).creationCode;
+        bytes32 salt = bytes32(uint256(keccak256(abi.encodePacked("MockDisputeGameFactory.op-challenger"))) + 1);
+        address addr;
+
         vm.broadcast();
-        MockDisputeGameFactory mock = new MockDisputeGameFactory();
+        assembly {
+            addr := create2(0, add(bytecode, 0x20), mload(bytecode), salt)
+        }
 
         // Write the address to the devnet ENV
-        console.log(string.concat("ENV Variable: export OP_CHALLENGER_DGF=\"", vm.toString(address(mock)), "\""));
+        console.log(string.concat("ENV Variable: export OP_CHALLENGER_DGF=\"", vm.toString(addr), "\""));
     }
 }


### PR DESCRIPTION
# Overview

Deploys the mock dispute game factory with `create2` so that we never have to update our devnet env