### PR TITLE
feat: `solvers` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1989,6 +1989,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ethers",
+ "op-challenger-driver",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1990,6 +1990,8 @@ dependencies = [
  "anyhow",
  "ethers",
  "op-challenger-driver",
+ "serde",
+ "serde_json",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,6 +1984,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "op-challenger-solvers"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "ethers",
+ "tracing",
+]
+
+[[package]]
 name = "op-challenger-tui"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,2 @@
 [workspace]
-members = [
-  "bin",
-  "crates/driver",
-  "crates/tui",
-]
+members = ["bin", "crates/driver", "crates/tui", "crates/solvers"]

--- a/crates/solvers/Cargo.toml
+++ b/crates/solvers/Cargo.toml
@@ -9,3 +9,6 @@ edition = "2021"
 anyhow = "1.0.70"
 tracing = "0.1.37"
 ethers = { version = "2.0.1", features = ["ws"] }
+
+[dev-dependencies]
+op-challenger-driver = { path = "../driver" }

--- a/crates/solvers/Cargo.toml
+++ b/crates/solvers/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "op-challenger-solvers"
+description = "Game solvers for the op-challenger"
+authors = ["clabby"]
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0.70"
+tracing = "0.1.37"
+ethers = { version = "2.0.1", features = ["ws"] }

--- a/crates/solvers/Cargo.toml
+++ b/crates/solvers/Cargo.toml
@@ -9,6 +9,8 @@ edition = "2021"
 anyhow = "1.0.70"
 tracing = "0.1.37"
 ethers = { version = "2.0.1", features = ["ws"] }
+serde = "1.0.159"
+serde_json = "1.0.95"
 
 [dev-dependencies]
 op-challenger-driver = { path = "../driver" }

--- a/crates/solvers/src/fault/alphabet.rs
+++ b/crates/solvers/src/fault/alphabet.rs
@@ -1,0 +1,131 @@
+//! The alphabet module contains an implementation of the [Game] trait for the
+//! alphabet fault dispute game.
+
+use super::{Claim, ClaimData, Game, Position, Response};
+use anyhow::{anyhow, Result};
+use ethers::{
+    abi::{self, Token},
+    types::{Address, Bytes, U256},
+    utils::keccak256,
+};
+use std::sync::Arc;
+
+/// The maximum depth of the alphabet game.
+/// TODO: This should be 64; Pad the tree.
+const MAX_DEPTH: u64 = 4;
+
+/// A struct containing information and the world state of a [FaultDisputeGame].
+pub struct AlphabetGame {
+    /// The address of the dispute game contract.
+    pub address: Address,
+    /// The UNIX timestamp of the game's creation.
+    pub created_at: u128,
+    /// The current state of the game DAG.
+    pub state: Vec<ClaimData>,
+    /// Our full execution trace
+    pub trace: Arc<[u8]>,
+}
+
+impl Game<u8> for AlphabetGame {
+    fn respond(&self, parent_index: usize) -> Result<Response> {
+        let parent_claim = self
+            .state
+            .get(parent_index)
+            .ok_or(anyhow!("Invalid parent index"))?;
+
+        let mut secondary_move_pos = None;
+        let mut is_attack = false;
+
+        // Fetch our version of the parent claim.
+        let our_parent_claim = self.claim_at(parent_claim.position)?;
+        if our_parent_claim == parent_claim.claim {
+            // The parent claim is valid according to our trace; Do nothing.
+            return Ok(Response::DoNothing);
+        }
+
+        if parent_claim.parent_index as u32 == u32::MAX {
+            // The parent claim is the root claim; Our only option is to attack it.
+            is_attack = true;
+        } else {
+            // Fetch our version of the grandparent claim.
+            let grandparent_claim = self
+                .state
+                .get(parent_claim.parent_index)
+                .ok_or(anyhow!("Invalid grandparent index"))?;
+            let our_grandparent_claim = self.claim_at(grandparent_claim.position)?;
+
+            if our_parent_claim != parent_claim.claim {
+                // Attack the parent; We disagree with it.
+                is_attack = true;
+
+                if our_grandparent_claim != grandparent_claim.claim {
+                    // Attack the grandparent as a secondary move; We disagree with it as well.
+                    secondary_move_pos = Some(grandparent_claim.position.make_move(is_attack));
+                }
+            }
+        }
+
+        // Compute the position of the primary move.
+        let move_pos = parent_claim.position.make_move(is_attack);
+
+        // If we are past the maximum depth, perform a step.
+        if move_pos.depth() > MAX_DEPTH {
+            let state_index = 0;
+            let pre_state_preimage = Bytes::default();
+            let proof = Bytes::default();
+
+            // First, we need to find the pre/post state index within the claim data depending
+            // on whether we are making an attack or defense step. If the index at depth of the
+            // move position is 0, it is an attack where the prestate is the absolute prestate.
+            if move_pos.index_at_depth() > 0 {
+                let leaf_pos = if is_attack {
+                    parent_claim.position - 1
+                } else {
+                    parent_claim.position + 1
+                };
+                let mut state_pos = leaf_pos;
+
+                // Find the highest position that commits to the same trace index as the leaf.
+                while state_pos.parent().right_index(MAX_DEPTH) == leaf_pos {
+                    state_pos = state_pos.parent();
+                }
+
+                // Search for the index of the claim that commits to the prestate's trace index.
+                todo!()
+            }
+
+            Ok(Response::Step(
+                state_index,
+                parent_index,
+                is_attack,
+                pre_state_preimage,
+                proof,
+            ))
+        } else {
+            // Find the trace index that our next claim must commit to.
+            Ok(Response::Move(
+                is_attack,
+                self.claim_at(move_pos)?,
+                secondary_move_pos
+                    // TODO: Safeguard unwrap.
+                    .map(|pos| (parent_claim.parent_index, self.claim_at(pos).unwrap())),
+            ))
+        }
+    }
+
+    fn state_at(&self, position: u128) -> Result<u8> {
+        self.trace
+            .get(position.trace_index(MAX_DEPTH) as usize)
+            .copied()
+            .ok_or(anyhow!("Invalid trace index"))
+    }
+
+    fn claim_at(&self, position: u128) -> Result<Claim> {
+        let trace_at = self.state_at(position)?;
+        let claim_hash = keccak256(abi::encode(&[
+            Token::Uint(U256::from(position.trace_index(MAX_DEPTH))),
+            Token::Uint(U256::from(trace_at)),
+        ]));
+        Ok(Claim::from(claim_hash))
+    }
+}

--- a/crates/solvers/src/fault/alphabet.rs
+++ b/crates/solvers/src/fault/alphabet.rs
@@ -1,7 +1,7 @@
 //! The alphabet module contains an implementation of the [Game] trait for the
 //! alphabet fault dispute game.
 
-use super::{Claim, ClaimData, Game, Position, Response};
+use super::{Claim, ClaimData, FaultGame, Position, Response};
 use anyhow::{anyhow, Result};
 use ethers::{
     abi::{self, Token},
@@ -26,7 +26,7 @@ pub struct AlphabetGame {
     pub trace: Arc<[u8]>,
 }
 
-impl Game<u8> for AlphabetGame {
+impl FaultGame<u8> for AlphabetGame {
     fn respond(&self, parent_index: usize) -> Result<Response> {
         let parent = self.claim_data(parent_index)?;
 

--- a/crates/solvers/src/fault/alphabet.rs
+++ b/crates/solvers/src/fault/alphabet.rs
@@ -8,6 +8,7 @@ use ethers::{
     types::{Address, Bytes, U256},
     utils::keccak256,
 };
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 /// The maximum depth of the alphabet game.
@@ -15,6 +16,8 @@ use std::sync::Arc;
 const MAX_DEPTH: u64 = 4;
 
 /// A struct containing information and the world state of a [op-challenger-driver::bindings::FaultDisputeGame].
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AlphabetGame {
     /// The address of the dispute game contract.
     pub address: Address,

--- a/crates/solvers/src/fault/alphabet.rs
+++ b/crates/solvers/src/fault/alphabet.rs
@@ -28,10 +28,7 @@ pub struct AlphabetGame {
 
 impl Game<u8> for AlphabetGame {
     fn respond(&self, parent_index: usize) -> Result<Response> {
-        let parent = self
-            .state
-            .get(parent_index)
-            .ok_or(anyhow!("Invalid parent index"))?;
+        let parent = self.claim_data(parent_index)?;
 
         let mut is_attack = false;
         let mut secondary_move_pos = None;
@@ -48,10 +45,7 @@ impl Game<u8> for AlphabetGame {
             is_attack = true;
         } else {
             // Fetch our version of the grandparent claim.
-            let grandparent = self
-                .state
-                .get(parent.parent_index)
-                .ok_or(anyhow!("Invalid grandparent index"))?;
+            let grandparent = self.claim_data(parent.parent_index)?;
             let our_grandparent_claim = self.claim_at(grandparent.position)?;
 
             if our_parent_claim != parent.claim {
@@ -92,10 +86,7 @@ impl Game<u8> for AlphabetGame {
                 let mut state_claim = parent;
                 while state_claim.position.right_index(MAX_DEPTH) != leaf_pos {
                     state_index = state_claim.parent_index;
-                    state_claim = self
-                        .state
-                        .get(state_index)
-                        .ok_or(anyhow!("Invalid parent index"))?;
+                    state_claim = self.claim_data(state_index)?;
                 }
             }
 
@@ -114,6 +105,10 @@ impl Game<u8> for AlphabetGame {
                     .map(|pos| (parent.parent_index, self.claim_at(pos).unwrap_or_default())),
             ))
         }
+    }
+
+    fn claim_data(&self, index: usize) -> Result<&ClaimData> {
+        self.state.get(index).ok_or(anyhow!("Invalid claim index"))
     }
 
     fn state_at(&self, position: u128) -> Result<u8> {

--- a/crates/solvers/src/fault/alphabet.rs
+++ b/crates/solvers/src/fault/alphabet.rs
@@ -69,6 +69,7 @@ impl Game<u8> for AlphabetGame {
         let move_pos = parent.position.make_move(is_attack);
 
         // If we are past the maximum depth, perform a step.
+        // Otherwise, make a move.
         if move_pos.depth() > MAX_DEPTH {
             let mut state_index = 0;
             let pre_state_preimage = Bytes::default();
@@ -93,7 +94,9 @@ impl Game<u8> for AlphabetGame {
                 // Search for the index of the claim that commits to the prestate's trace index.
                 // TODO: This isn't sufficient for a game with multiple participants. There can
                 // be multiple claims that exist at the same position. We want the one on the
-                // same path as the trace we're countering.
+                // same path as the trace we're countering. To do this, we can walk up the DAG
+                // starting from the parent and find the claim at the desired `state_pos` rather
+                // than searching the full game state.
                 state_index = self
                     .state
                     .iter()
@@ -111,7 +114,6 @@ impl Game<u8> for AlphabetGame {
                 proof,
             ))
         } else {
-            // Find the trace index that our next claim must commit to.
             Ok(Response::Move(
                 is_attack,
                 self.claim_at(move_pos)?,

--- a/crates/solvers/src/fault/alphabet.rs
+++ b/crates/solvers/src/fault/alphabet.rs
@@ -14,12 +14,12 @@ use std::sync::Arc;
 /// TODO: This should be 63; Pad the tree.
 const MAX_DEPTH: u64 = 4;
 
-/// A struct containing information and the world state of a [FaultDisputeGame].
+/// A struct containing information and the world state of a [op-challenger-driver::bindings::FaultDisputeGame].
 pub struct AlphabetGame {
     /// The address of the dispute game contract.
     pub address: Address,
     /// The UNIX timestamp of the game's creation.
-    pub created_at: u128,
+    pub created_at: u64,
     /// The current state of the game DAG.
     pub state: Vec<ClaimData>,
     /// Our full execution trace

--- a/crates/solvers/src/fault/game.rs
+++ b/crates/solvers/src/fault/game.rs
@@ -1,11 +1,11 @@
-//! The game module holds the [Game] trait.
+//! The game module holds the [FaultGame] trait.
 
-use crate::fault::types::{Claim, ClaimData, Response};
+use super::{Claim, ClaimData, Response};
 use anyhow::Result;
 
-/// The [Game] trait defines the interface for a local copy of an onchain fault dispute game.
-pub trait Game<T> {
-    /// Respond to a [crate::Claim] made by a participant in the dispute game.
+/// The [FaultGame] trait defines the interface for a local copy of an onchain fault dispute game.
+pub trait FaultGame<T> {
+    /// Respond to a [Claim] made by a participant in the dispute game.
     ///
     /// ### Takes
     /// - `parent_index`: The index of the parent claim in the DAG array.

--- a/crates/solvers/src/fault/game.rs
+++ b/crates/solvers/src/fault/game.rs
@@ -1,0 +1,40 @@
+//! The game module holds the [Game] trait.
+
+use crate::fault::types::{Claim, Response};
+use anyhow::Result;
+
+/// The [Game] trait defines the interface for a local copy of an onchain fault dispute game.
+pub trait Game<T> {
+    /// Respond to a [crate::Claim] made by a participant in the dispute game.
+    ///
+    /// ### Takes
+    /// - `parent_index`: The index of the parent claim in the DAG array.
+    ///
+    /// ### Returns
+    /// - `Ok(Response)`: The response to the claim.
+    /// - `Err(anyhow::Error)`: An error occurred while determining the correct response to the
+    ///    [Claim].
+    fn respond(&self, parent_index: usize) -> Result<Response>;
+
+    /// Fetch the state at the given position in the game tree. This state is always correct in
+    /// the relative view of the participant.
+    ///
+    /// ### Takes
+    /// - `position`: The position of the state within the game tree.
+    ///
+    /// ### Returns
+    /// - `Ok(T)`: The state at the given position.
+    /// - `Err(anyhow::Error)`: An error occurred while fetching the state.
+    fn state_at(&self, position: u128) -> Result<T>;
+
+    /// Fetch the [Claim] at the given position in the game tree. This [Claim] is always true in
+    /// the relative view of the participant.
+    ///
+    /// ### Takes
+    /// - `position`: The position of the claim within the game tree.
+    ///
+    /// ### Returns
+    /// - `Ok(Claim)`: The [Claim] at the given position.
+    /// - `Err(anyhow::Error)`: An error occurred while fetching the claim.
+    fn claim_at(&self, position: u128) -> Result<Claim>;
+}

--- a/crates/solvers/src/fault/game.rs
+++ b/crates/solvers/src/fault/game.rs
@@ -1,6 +1,6 @@
 //! The game module holds the [Game] trait.
 
-use crate::fault::types::{Claim, Response};
+use crate::fault::types::{Claim, ClaimData, Response};
 use anyhow::Result;
 
 /// The [Game] trait defines the interface for a local copy of an onchain fault dispute game.
@@ -15,6 +15,16 @@ pub trait Game<T> {
     /// - `Err(anyhow::Error)`: An error occurred while determining the correct response to the
     ///    [Claim].
     fn respond(&self, parent_index: usize) -> Result<Response>;
+
+    /// Fetch the [ClaimData] at the given index in the DAG array.
+    ///
+    /// ### Takes
+    /// - `index`: The index of the claim in the DAG array.
+    ///
+    /// ### Returns
+    /// - `Ok(ClaimData)`: The [ClaimData] at the given index.
+    /// - `Err(anyhow::Error)`: An error occurred while fetching the [ClaimData].
+    fn claim_data(&self, index: usize) -> Result<&ClaimData>;
 
     /// Fetch the state at the given position in the game tree. This state is always correct in
     /// the relative view of the participant.

--- a/crates/solvers/src/fault/mod.rs
+++ b/crates/solvers/src/fault/mod.rs
@@ -8,7 +8,7 @@ mod types;
 pub use types::*;
 
 mod game;
-pub use game::Game;
+pub use game::FaultGame;
 
 mod alphabet;
 pub use alphabet::AlphabetGame;

--- a/crates/solvers/src/fault/mod.rs
+++ b/crates/solvers/src/fault/mod.rs
@@ -1,0 +1,14 @@
+//! Data structures, types, and the game solver implementation for the various
+//! fault dispute game variants.
+
+mod position;
+pub use position::{compute_gindex, Position};
+
+mod types;
+pub use types::*;
+
+mod game;
+pub use game::Game;
+
+mod alphabet;
+pub use alphabet::AlphabetGame;

--- a/crates/solvers/src/fault/position.rs
+++ b/crates/solvers/src/fault/position.rs
@@ -48,7 +48,7 @@ impl Position for u128 {
     }
 
     fn right(&self) -> Self {
-        (self << 1) | 1
+        self.left() | 1
     }
 
     fn parent(&self) -> Self {

--- a/crates/solvers/src/fault/position.rs
+++ b/crates/solvers/src/fault/position.rs
@@ -1,0 +1,328 @@
+//! The position module holds the [Position] trait and its implementations.
+
+/// The [Position] trait defines the interface of a generalized index within a binary tree.
+/// A "Generalized Index" is calculated as `2^{depth} + index_at_depth`.
+pub trait Position {
+    /// Returns the depth of the [Position] within the tree.
+    fn depth(&self) -> u64;
+    /// Returns the index at depth of the [Position] within the tree.
+    fn index_at_depth(&self) -> u64;
+    /// Returns the left child [Position] relative to the current [Position].
+    fn left(&self) -> Self;
+    /// Returns the right child [Position] relative to the current [Position].
+    fn right(&self) -> Self;
+    /// Returns the parent [Position] relative to the current [Position].
+    fn parent(&self) -> Self;
+    /// Returns the rightmost [Position] that commits to the same trace index as the current [Position].
+    fn right_index(&self, max_depth: u64) -> Self;
+    /// Returns the trace index that the current [Position] commits to.
+    fn trace_index(&self, max_depth: u64) -> u64;
+    /// Returns the relative [Position] for an attack or defense move against the current [Position].
+    fn make_move(&self, is_attack: bool) -> Self;
+}
+
+/// Computes a generalized index from a depth and index at depth.
+///
+/// ### Takes
+/// - `depth`: The depth of the generalized index.
+/// - `index_at_depth`: The index at depth of the generalized index.
+///
+/// ### Returns
+/// - `u128`: The generalized index: `2^{depth} + index_at_depth`.
+pub fn compute_gindex(depth: u8, index_at_depth: u64) -> u128 {
+    2u128.pow(depth as u32) + index_at_depth as u128
+}
+
+/// Implementation of the [Position] trait for the [std::u128] primitive type.
+impl Position for u128 {
+    fn depth(&self) -> u64 {
+        127 - self.leading_zeros() as u64
+    }
+
+    fn index_at_depth(&self) -> u64 {
+        (self - (1 << self.depth())) as u64
+    }
+
+    fn left(&self) -> Self {
+        self << 1
+    }
+
+    fn right(&self) -> Self {
+        (self << 1) | 1
+    }
+
+    fn parent(&self) -> Self {
+        self >> 1
+    }
+
+    fn right_index(&self, max_depth: u64) -> Self {
+        let remaining = max_depth - self.depth();
+        (self << remaining) | ((1 << remaining) - 1)
+    }
+
+    fn trace_index(&self, max_depth: u64) -> u64 {
+        self.right_index(max_depth).index_at_depth()
+    }
+
+    fn make_move(&self, is_attack: bool) -> Self {
+        ((!is_attack as u128) | self) << 1
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{compute_gindex, Position};
+
+    const MAX_DEPTH: u64 = 4;
+
+    #[test]
+    fn position_correctness_static() {
+        let mut p = compute_gindex(0, 0);
+        assert_eq!(p, 1);
+        assert_eq!(p.depth(), 0);
+        assert_eq!(p.index_at_depth(), 0);
+        let mut r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 31);
+        assert_eq!(r.index_at_depth(), 15);
+
+        p = compute_gindex(1, 0);
+        assert_eq!(p, 2);
+        assert_eq!(p.depth(), 1);
+        assert_eq!(p.index_at_depth(), 0);
+        r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 23);
+        assert_eq!(r.index_at_depth(), 7);
+
+        p = compute_gindex(1, 1);
+        assert_eq!(p, 3);
+        assert_eq!(p.depth(), 1);
+        assert_eq!(p.index_at_depth(), 1);
+        r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 31);
+        assert_eq!(r.index_at_depth(), 15);
+
+        p = compute_gindex(2, 0);
+        assert_eq!(p, 4);
+        assert_eq!(p.depth(), 2);
+        assert_eq!(p.index_at_depth(), 0);
+        r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 19);
+        assert_eq!(r.index_at_depth(), 3);
+
+        p = compute_gindex(2, 1);
+        assert_eq!(p, 5);
+        assert_eq!(p.depth(), 2);
+        assert_eq!(p.index_at_depth(), 1);
+        r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 23);
+        assert_eq!(r.index_at_depth(), 7);
+
+        p = compute_gindex(2, 2);
+        assert_eq!(p, 6);
+        assert_eq!(p.depth(), 2);
+        assert_eq!(p.index_at_depth(), 2);
+        r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 27);
+        assert_eq!(r.index_at_depth(), 11);
+
+        p = compute_gindex(2, 3);
+        assert_eq!(p, 7);
+        assert_eq!(p.depth(), 2);
+        assert_eq!(p.index_at_depth(), 3);
+        r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 31);
+        assert_eq!(r.index_at_depth(), 15);
+
+        p = compute_gindex(3, 0);
+        assert_eq!(p, 8);
+        assert_eq!(p.depth(), 3);
+        assert_eq!(p.index_at_depth(), 0);
+        r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 17);
+        assert_eq!(r.index_at_depth(), 1);
+
+        p = compute_gindex(3, 1);
+        assert_eq!(p, 9);
+        assert_eq!(p.depth(), 3);
+        assert_eq!(p.index_at_depth(), 1);
+        r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 19);
+        assert_eq!(r.index_at_depth(), 3);
+
+        p = compute_gindex(3, 2);
+        assert_eq!(p, 10);
+        assert_eq!(p.depth(), 3);
+        assert_eq!(p.index_at_depth(), 2);
+        r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 21);
+        assert_eq!(r.index_at_depth(), 5);
+
+        p = compute_gindex(3, 3);
+        assert_eq!(p, 11);
+        assert_eq!(p.depth(), 3);
+        assert_eq!(p.index_at_depth(), 3);
+        r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 23);
+        assert_eq!(r.index_at_depth(), 7);
+
+        p = compute_gindex(3, 4);
+        assert_eq!(p, 12);
+        assert_eq!(p.depth(), 3);
+        assert_eq!(p.index_at_depth(), 4);
+        r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 25);
+        assert_eq!(r.index_at_depth(), 9);
+
+        p = compute_gindex(3, 5);
+        assert_eq!(p, 13);
+        assert_eq!(p.depth(), 3);
+        assert_eq!(p.index_at_depth(), 5);
+        r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 27);
+        assert_eq!(r.index_at_depth(), 11);
+
+        p = compute_gindex(3, 6);
+        assert_eq!(p, 14);
+        assert_eq!(p.depth(), 3);
+        assert_eq!(p.index_at_depth(), 6);
+        r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 29);
+        assert_eq!(r.index_at_depth(), 13);
+
+        p = compute_gindex(3, 7);
+        assert_eq!(p, 15);
+        assert_eq!(p.depth(), 3);
+        assert_eq!(p.index_at_depth(), 7);
+        r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 31);
+        assert_eq!(r.index_at_depth(), 15);
+
+        p = compute_gindex(4, 0);
+        assert_eq!(p, 16);
+        assert_eq!(p.depth(), 4);
+        assert_eq!(p.index_at_depth(), 0);
+        r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 16);
+        assert_eq!(r.index_at_depth(), 0);
+
+        p = compute_gindex(4, 1);
+        assert_eq!(p, 17);
+        assert_eq!(p.depth(), 4);
+        assert_eq!(p.index_at_depth(), 1);
+        r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 17);
+        assert_eq!(r.index_at_depth(), 1);
+
+        p = compute_gindex(4, 2);
+        assert_eq!(p, 18);
+        assert_eq!(p.depth(), 4);
+        assert_eq!(p.index_at_depth(), 2);
+        r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 18);
+        assert_eq!(r.index_at_depth(), 2);
+
+        p = compute_gindex(4, 3);
+        assert_eq!(p, 19);
+        assert_eq!(p.depth(), 4);
+        assert_eq!(p.index_at_depth(), 3);
+        r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 19);
+        assert_eq!(r.index_at_depth(), 3);
+
+        p = compute_gindex(4, 4);
+        assert_eq!(p, 20);
+        assert_eq!(p.depth(), 4);
+        assert_eq!(p.index_at_depth(), 4);
+        r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 20);
+        assert_eq!(r.index_at_depth(), 4);
+
+        p = compute_gindex(4, 5);
+        assert_eq!(p, 21);
+        assert_eq!(p.depth(), 4);
+        assert_eq!(p.index_at_depth(), 5);
+        r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 21);
+        assert_eq!(r.index_at_depth(), 5);
+
+        p = compute_gindex(4, 6);
+        assert_eq!(p, 22);
+        assert_eq!(p.depth(), 4);
+        assert_eq!(p.index_at_depth(), 6);
+        r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 22);
+        assert_eq!(r.index_at_depth(), 6);
+
+        p = compute_gindex(4, 7);
+        assert_eq!(p, 23);
+        assert_eq!(p.depth(), 4);
+        assert_eq!(p.index_at_depth(), 7);
+        r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 23);
+        assert_eq!(r.index_at_depth(), 7);
+
+        p = compute_gindex(4, 8);
+        assert_eq!(p, 24);
+        assert_eq!(p.depth(), 4);
+        assert_eq!(p.index_at_depth(), 8);
+        r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 24);
+        assert_eq!(r.index_at_depth(), 8);
+
+        p = compute_gindex(4, 9);
+        assert_eq!(p, 25);
+        assert_eq!(p.depth(), 4);
+        assert_eq!(p.index_at_depth(), 9);
+        r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 25);
+        assert_eq!(r.index_at_depth(), 9);
+
+        p = compute_gindex(4, 10);
+        assert_eq!(p, 26);
+        assert_eq!(p.depth(), 4);
+        assert_eq!(p.index_at_depth(), 10);
+        r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 26);
+        assert_eq!(r.index_at_depth(), 10);
+
+        p = compute_gindex(4, 11);
+        assert_eq!(p, 27);
+        assert_eq!(p.depth(), 4);
+        assert_eq!(p.index_at_depth(), 11);
+        r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 27);
+        assert_eq!(r.index_at_depth(), 11);
+
+        p = compute_gindex(4, 12);
+        assert_eq!(p, 28);
+        assert_eq!(p.depth(), 4);
+        assert_eq!(p.index_at_depth(), 12);
+        r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 28);
+        assert_eq!(r.index_at_depth(), 12);
+
+        p = compute_gindex(4, 13);
+        assert_eq!(p, 29);
+        assert_eq!(p.depth(), 4);
+        assert_eq!(p.index_at_depth(), 13);
+        r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 29);
+        assert_eq!(r.index_at_depth(), 13);
+
+        p = compute_gindex(4, 14);
+        assert_eq!(p, 30);
+        assert_eq!(p.depth(), 4);
+        assert_eq!(p.index_at_depth(), 14);
+        r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 30);
+        assert_eq!(r.index_at_depth(), 14);
+
+        p = compute_gindex(4, 15);
+        assert_eq!(p, 31);
+        assert_eq!(p.depth(), 4);
+        assert_eq!(p.index_at_depth(), 15);
+        r = p.right_index(MAX_DEPTH);
+        assert_eq!(r, 31);
+        assert_eq!(r.index_at_depth(), 15);
+    }
+}

--- a/crates/solvers/src/fault/position.rs
+++ b/crates/solvers/src/fault/position.rs
@@ -71,258 +71,59 @@ impl Position for u128 {
 
 #[cfg(test)]
 mod test {
-    use super::{compute_gindex, Position};
+    use super::Position;
+
+    /// A helper struct for testing the [Position] trait implementation for [std::u128].
+    /// 0. `u64` - `depth`
+    /// 1. `u64` - `index_at_depth`
+    /// 2. `u128` - `right_index`
+    /// 3. `u64` - `trace_index`
+    struct PositionMetaData(u64, u64, u128, u64);
 
     const MAX_DEPTH: u64 = 4;
+    const EXPECTED_VALUES: &[PositionMetaData] = &[
+        PositionMetaData(0, 0, 31, 15),
+        PositionMetaData(1, 0, 23, 7),
+        PositionMetaData(1, 1, 31, 15),
+        PositionMetaData(2, 0, 19, 3),
+        PositionMetaData(2, 1, 23, 7),
+        PositionMetaData(2, 2, 27, 11),
+        PositionMetaData(2, 3, 31, 15),
+        PositionMetaData(3, 0, 17, 1),
+        PositionMetaData(3, 1, 19, 3),
+        PositionMetaData(3, 2, 21, 5),
+        PositionMetaData(3, 3, 23, 7),
+        PositionMetaData(3, 4, 25, 9),
+        PositionMetaData(3, 5, 27, 11),
+        PositionMetaData(3, 6, 29, 13),
+        PositionMetaData(3, 7, 31, 15),
+        PositionMetaData(4, 0, 16, 0),
+        PositionMetaData(4, 1, 17, 1),
+        PositionMetaData(4, 2, 18, 2),
+        PositionMetaData(4, 3, 19, 3),
+        PositionMetaData(4, 4, 20, 4),
+        PositionMetaData(4, 5, 21, 5),
+        PositionMetaData(4, 6, 22, 6),
+        PositionMetaData(4, 7, 23, 7),
+        PositionMetaData(4, 8, 24, 8),
+        PositionMetaData(4, 9, 25, 9),
+        PositionMetaData(4, 10, 26, 10),
+        PositionMetaData(4, 11, 27, 11),
+        PositionMetaData(4, 12, 28, 12),
+        PositionMetaData(4, 13, 29, 13),
+        PositionMetaData(4, 14, 30, 14),
+        PositionMetaData(4, 15, 31, 15),
+    ];
 
     #[test]
     fn position_correctness_static() {
-        let mut p = compute_gindex(0, 0);
-        assert_eq!(p, 1);
-        assert_eq!(p.depth(), 0);
-        assert_eq!(p.index_at_depth(), 0);
-        let mut r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 31);
-        assert_eq!(r.index_at_depth(), 15);
-
-        p = compute_gindex(1, 0);
-        assert_eq!(p, 2);
-        assert_eq!(p.depth(), 1);
-        assert_eq!(p.index_at_depth(), 0);
-        r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 23);
-        assert_eq!(r.index_at_depth(), 7);
-
-        p = compute_gindex(1, 1);
-        assert_eq!(p, 3);
-        assert_eq!(p.depth(), 1);
-        assert_eq!(p.index_at_depth(), 1);
-        r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 31);
-        assert_eq!(r.index_at_depth(), 15);
-
-        p = compute_gindex(2, 0);
-        assert_eq!(p, 4);
-        assert_eq!(p.depth(), 2);
-        assert_eq!(p.index_at_depth(), 0);
-        r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 19);
-        assert_eq!(r.index_at_depth(), 3);
-
-        p = compute_gindex(2, 1);
-        assert_eq!(p, 5);
-        assert_eq!(p.depth(), 2);
-        assert_eq!(p.index_at_depth(), 1);
-        r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 23);
-        assert_eq!(r.index_at_depth(), 7);
-
-        p = compute_gindex(2, 2);
-        assert_eq!(p, 6);
-        assert_eq!(p.depth(), 2);
-        assert_eq!(p.index_at_depth(), 2);
-        r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 27);
-        assert_eq!(r.index_at_depth(), 11);
-
-        p = compute_gindex(2, 3);
-        assert_eq!(p, 7);
-        assert_eq!(p.depth(), 2);
-        assert_eq!(p.index_at_depth(), 3);
-        r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 31);
-        assert_eq!(r.index_at_depth(), 15);
-
-        p = compute_gindex(3, 0);
-        assert_eq!(p, 8);
-        assert_eq!(p.depth(), 3);
-        assert_eq!(p.index_at_depth(), 0);
-        r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 17);
-        assert_eq!(r.index_at_depth(), 1);
-
-        p = compute_gindex(3, 1);
-        assert_eq!(p, 9);
-        assert_eq!(p.depth(), 3);
-        assert_eq!(p.index_at_depth(), 1);
-        r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 19);
-        assert_eq!(r.index_at_depth(), 3);
-
-        p = compute_gindex(3, 2);
-        assert_eq!(p, 10);
-        assert_eq!(p.depth(), 3);
-        assert_eq!(p.index_at_depth(), 2);
-        r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 21);
-        assert_eq!(r.index_at_depth(), 5);
-
-        p = compute_gindex(3, 3);
-        assert_eq!(p, 11);
-        assert_eq!(p.depth(), 3);
-        assert_eq!(p.index_at_depth(), 3);
-        r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 23);
-        assert_eq!(r.index_at_depth(), 7);
-
-        p = compute_gindex(3, 4);
-        assert_eq!(p, 12);
-        assert_eq!(p.depth(), 3);
-        assert_eq!(p.index_at_depth(), 4);
-        r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 25);
-        assert_eq!(r.index_at_depth(), 9);
-
-        p = compute_gindex(3, 5);
-        assert_eq!(p, 13);
-        assert_eq!(p.depth(), 3);
-        assert_eq!(p.index_at_depth(), 5);
-        r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 27);
-        assert_eq!(r.index_at_depth(), 11);
-
-        p = compute_gindex(3, 6);
-        assert_eq!(p, 14);
-        assert_eq!(p.depth(), 3);
-        assert_eq!(p.index_at_depth(), 6);
-        r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 29);
-        assert_eq!(r.index_at_depth(), 13);
-
-        p = compute_gindex(3, 7);
-        assert_eq!(p, 15);
-        assert_eq!(p.depth(), 3);
-        assert_eq!(p.index_at_depth(), 7);
-        r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 31);
-        assert_eq!(r.index_at_depth(), 15);
-
-        p = compute_gindex(4, 0);
-        assert_eq!(p, 16);
-        assert_eq!(p.depth(), 4);
-        assert_eq!(p.index_at_depth(), 0);
-        r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 16);
-        assert_eq!(r.index_at_depth(), 0);
-
-        p = compute_gindex(4, 1);
-        assert_eq!(p, 17);
-        assert_eq!(p.depth(), 4);
-        assert_eq!(p.index_at_depth(), 1);
-        r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 17);
-        assert_eq!(r.index_at_depth(), 1);
-
-        p = compute_gindex(4, 2);
-        assert_eq!(p, 18);
-        assert_eq!(p.depth(), 4);
-        assert_eq!(p.index_at_depth(), 2);
-        r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 18);
-        assert_eq!(r.index_at_depth(), 2);
-
-        p = compute_gindex(4, 3);
-        assert_eq!(p, 19);
-        assert_eq!(p.depth(), 4);
-        assert_eq!(p.index_at_depth(), 3);
-        r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 19);
-        assert_eq!(r.index_at_depth(), 3);
-
-        p = compute_gindex(4, 4);
-        assert_eq!(p, 20);
-        assert_eq!(p.depth(), 4);
-        assert_eq!(p.index_at_depth(), 4);
-        r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 20);
-        assert_eq!(r.index_at_depth(), 4);
-
-        p = compute_gindex(4, 5);
-        assert_eq!(p, 21);
-        assert_eq!(p.depth(), 4);
-        assert_eq!(p.index_at_depth(), 5);
-        r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 21);
-        assert_eq!(r.index_at_depth(), 5);
-
-        p = compute_gindex(4, 6);
-        assert_eq!(p, 22);
-        assert_eq!(p.depth(), 4);
-        assert_eq!(p.index_at_depth(), 6);
-        r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 22);
-        assert_eq!(r.index_at_depth(), 6);
-
-        p = compute_gindex(4, 7);
-        assert_eq!(p, 23);
-        assert_eq!(p.depth(), 4);
-        assert_eq!(p.index_at_depth(), 7);
-        r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 23);
-        assert_eq!(r.index_at_depth(), 7);
-
-        p = compute_gindex(4, 8);
-        assert_eq!(p, 24);
-        assert_eq!(p.depth(), 4);
-        assert_eq!(p.index_at_depth(), 8);
-        r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 24);
-        assert_eq!(r.index_at_depth(), 8);
-
-        p = compute_gindex(4, 9);
-        assert_eq!(p, 25);
-        assert_eq!(p.depth(), 4);
-        assert_eq!(p.index_at_depth(), 9);
-        r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 25);
-        assert_eq!(r.index_at_depth(), 9);
-
-        p = compute_gindex(4, 10);
-        assert_eq!(p, 26);
-        assert_eq!(p.depth(), 4);
-        assert_eq!(p.index_at_depth(), 10);
-        r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 26);
-        assert_eq!(r.index_at_depth(), 10);
-
-        p = compute_gindex(4, 11);
-        assert_eq!(p, 27);
-        assert_eq!(p.depth(), 4);
-        assert_eq!(p.index_at_depth(), 11);
-        r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 27);
-        assert_eq!(r.index_at_depth(), 11);
-
-        p = compute_gindex(4, 12);
-        assert_eq!(p, 28);
-        assert_eq!(p.depth(), 4);
-        assert_eq!(p.index_at_depth(), 12);
-        r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 28);
-        assert_eq!(r.index_at_depth(), 12);
-
-        p = compute_gindex(4, 13);
-        assert_eq!(p, 29);
-        assert_eq!(p.depth(), 4);
-        assert_eq!(p.index_at_depth(), 13);
-        r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 29);
-        assert_eq!(r.index_at_depth(), 13);
-
-        p = compute_gindex(4, 14);
-        assert_eq!(p, 30);
-        assert_eq!(p.depth(), 4);
-        assert_eq!(p.index_at_depth(), 14);
-        r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 30);
-        assert_eq!(r.index_at_depth(), 14);
-
-        p = compute_gindex(4, 15);
-        assert_eq!(p, 31);
-        assert_eq!(p.depth(), 4);
-        assert_eq!(p.index_at_depth(), 15);
-        r = p.right_index(MAX_DEPTH);
-        assert_eq!(r, 31);
-        assert_eq!(r.index_at_depth(), 15);
+        for (p, v) in EXPECTED_VALUES.iter().enumerate() {
+            let pos = (p + 1) as u128;
+            assert_eq!(pos.depth(), v.0);
+            assert_eq!(pos.index_at_depth(), v.1);
+            let r = pos.right_index(MAX_DEPTH);
+            assert_eq!(r, v.2);
+            assert_eq!(r.index_at_depth(), v.3);
+        }
     }
 }

--- a/crates/solvers/src/fault/types.rs
+++ b/crates/solvers/src/fault/types.rs
@@ -1,0 +1,41 @@
+//! The types module contains all of the types relevant to the fault dispute game.
+
+use ethers::types::{Bytes, H256};
+
+/// The [Claim] type represents a claim on the execution trace at a given trace index that is
+/// made by a participant in a dispute game.
+pub type Claim = H256;
+
+/// The [Clock] struct represents a clock that is used to track the duration and timestamp of a
+/// given [Claim] within the game.
+pub struct Clock {
+    /// The duration remaining on the chess clock.
+    pub duration: u64,
+    /// The timestamp at which the clock was last updated.
+    pub timestamp: u64,
+}
+
+/// The [ClaimData] struct represents a [Claim] as well as the data associated with it.
+pub struct ClaimData {
+    /// The index of the parent claim in the DAG array.
+    pub parent_index: usize,
+    /// Whether or not the current claim has ever been countered.
+    pub countered: bool,
+    /// The claim that is being made at the trace index relative to the position.
+    pub claim: Claim,
+    /// The position of the claim within the game tree.
+    pub position: u128,
+    /// The clock that is used to track the duration elapsed and timestamp of the claim.
+    pub clock: Clock,
+}
+
+/// A [Response] is an action taken by a participant in the dispute game in response to
+/// a claim made by another participant.
+pub enum Response {
+    /// Do nothing.
+    DoNothing,
+    /// Create a counter claim against the parent claim and optionally the grandparent.
+    Move(bool, Claim, Option<(usize, Claim)>),
+    /// Perform a VM step against the parent claim.
+    Step(usize, usize, bool, Bytes, Bytes),
+}

--- a/crates/solvers/src/fault/types.rs
+++ b/crates/solvers/src/fault/types.rs
@@ -1,6 +1,7 @@
 //! The types module contains all of the types relevant to the fault dispute game.
 
 use ethers::types::{Bytes, H256};
+use serde::{Deserialize, Serialize};
 
 /// The [Claim] type represents a claim on the execution trace at a given trace index that is
 /// made by a participant in a dispute game.
@@ -8,6 +9,8 @@ pub type Claim = H256;
 
 /// The [Clock] struct represents a clock that is used to track the duration and timestamp of a
 /// given [Claim] within the game.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Clock {
     /// The duration remaining on the chess clock.
     pub duration: u64,
@@ -16,6 +19,8 @@ pub struct Clock {
 }
 
 /// The [ClaimData] struct represents a [Claim] as well as the data associated with it.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ClaimData {
     /// The index of the parent claim in the DAG array.
     pub parent_index: usize,

--- a/crates/solvers/src/lib.rs
+++ b/crates/solvers/src/lib.rs
@@ -1,0 +1,3 @@
+//! The `op-challenger-solvers` crate contains game solvers for the various types of dispute games.
+
+pub mod fault;


### PR DESCRIPTION
### Overview

Adds the `op-challenger-solvers` crate to hold all game solvers for the various dispute game types. The game solvers will serve as abstractions for determining proper responses to events that occur within dispute games captured by the `driver`.